### PR TITLE
global: fix import of invenio_upgrader

### DIFF
--- a/invenio_oauth2server/upgrades/oauth2server_2014_02_17_initial.py
+++ b/invenio_oauth2server/upgrades/oauth2server_2014_02_17_initial.py
@@ -22,7 +22,7 @@
 import warnings
 
 from invenio.ext.sqlalchemy import db
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 from sqlalchemy_utils.types import URLType
 

--- a/invenio_oauth2server/upgrades/oauth2server_2014_10_21_encrypted_token_columns.py
+++ b/invenio_oauth2server/upgrades/oauth2server_2014_10_21_encrypted_token_columns.py
@@ -18,7 +18,7 @@
 # 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
 
 from invenio.legacy.dbquery import run_sql
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 
 depends_on = [u'oauth2server_2014_02_17_initial']

--- a/invenio_oauth2server/upgrades/oauth2server_2015_07_14_innodb.py
+++ b/invenio_oauth2server/upgrades/oauth2server_2015_07_14_innodb.py
@@ -21,7 +21,7 @@
 
 from invenio.ext.sqlalchemy import db
 
-from invenio.modules.upgrader.api import op
+from invenio_upgrader.api import op
 
 
 depends_on = ['invenio_2015_03_03_tag_value']

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -27,3 +27,5 @@
 #
 #     -e git+git://github.com/mitsuhiko/werkzeug.git#egg=Werkzeug
 #     -e git+git://github.com/mitsuhiko/jinja2.git#egg=Jinja2
+
+-e git+git://github.com/inveniosoftware/invenio-upgrader.git#egg=invenio-upgrader

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ requirements = [
     # FIXME new oauthlib release after 0.7.2 has some compatible problems with
     # the used Flask-Oauthlib version.
     'oauthlib==0.7.2',
+    'invenio-upgrader>=0.1.0',
     'invenio-accounts>=0.1.0',
 ]
 


### PR DESCRIPTION
* FIX Fixes import of invenio_upgrader in the past upgrade recipes
  following its separation into standalone package.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>