### PR TITLE
config: prefix from OAUTH2 to OAUTH2SERVER

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -56,7 +56,7 @@ app.config.update(
     CELERY_CACHE_BACKEND="memory",
     CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
     CELERY_RESULT_BACKEND="cache",
-    OAUTH2_CACHE_TYPE='simple',
+    OAUTH2SERVER_CACHE_TYPE='simple',
     OAUTHLIB_INSECURE_TRANSPORT=True,
     SECRET_KEY='test_key',
     SECURITY_PASSWORD_HASH='plaintext',

--- a/invenio_oauth2server/config.py
+++ b/invenio_oauth2server/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015 CERN.
+# Copyright (C) 2014, 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -33,16 +33,16 @@ OAUTH2_PROVIDER_ERROR_ENDPOINT = 'invenio_oauth2server.errors'
 OAUTH2_PROVIDER_TOKEN_EXPIRES_IN = 3600
 """ Life time of an access token """
 
-OAUTH2_CLIENT_ID_SALT_LEN = 40
+OAUTH2SERVER_CLIENT_ID_SALT_LEN = 40
 """ Length of client id """
 
-OAUTH2_CLIENT_SECRET_SALT_LEN = 60
+OAUTH2SERVER_CLIENT_SECRET_SALT_LEN = 60
 """ Length of the client secret """
 
-OAUTH2_TOKEN_PERSONAL_SALT_LEN = 60
+OAUTH2SERVER_TOKEN_PERSONAL_SALT_LEN = 60
 """ Length of the personal access token """
 
-OAUTH2_ALLOWED_GRANT_TYPES = [
+OAUTH2SERVER_ALLOWED_GRANT_TYPES = [
     'authorization_code', 'client_credentials', 'refresh_token',
 ]
 """
@@ -52,7 +52,7 @@ disabled, as it requires the client application to gain access to the username
 and password of the resource owner
 """
 
-OAUTH2_ALLOWED_RESPONSE_TYPES = [
+OAUTH2SERVER_ALLOWED_RESPONSE_TYPES = [
     "code", "token"
 ]
 """

--- a/invenio_oauth2server/ext.py
+++ b/invenio_oauth2server/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,6 +27,7 @@
 from __future__ import absolute_import, print_function
 
 import os
+from warnings import warn
 
 import pkg_resources
 from flask_oauthlib.contrib.oauth2 import bind_cache_grant, bind_sqlalchemy
@@ -120,5 +121,5 @@ class InvenioOAuth2Server(object):
                            'invenio_oauth2server/settings/base.html'))
 
         for k in dir(config):
-            if k.startswith('OAUTH2_'):
+            if k.startswith('OAUTH2SERVER_') or k.startswith('OAUTH2_'):
                 app.config.setdefault(k, getattr(config, k))

--- a/invenio_oauth2server/models.py
+++ b/invenio_oauth2server/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -206,12 +206,12 @@ class Client(db.Model):
     @property
     def allowed_grant_types(self):
         """Return allowed grant types."""
-        return current_app.config['OAUTH2_ALLOWED_GRANT_TYPES']
+        return current_app.config['OAUTH2SERVER_ALLOWED_GRANT_TYPES']
 
     @property
     def allowed_response_types(self):
         """Return allowed response types."""
-        return current_app.config['OAUTH2_ALLOWED_RESPONSE_TYPES']
+        return current_app.config['OAUTH2SERVER_ALLOWED_RESPONSE_TYPES']
 
     # def validate_scopes(self, scopes):
     #     return self._validate_scopes
@@ -280,13 +280,13 @@ class Client(db.Model):
     def reset_client_id(self):
         """Reset client id."""
         self.client_id = gen_salt(
-            current_app.config.get('OAUTH2_CLIENT_ID_SALT_LEN')
+            current_app.config.get('OAUTH2SERVER_CLIENT_ID_SALT_LEN')
         )
 
     def reset_client_secret(self):
         """Reset client secret."""
         self.client_secret = gen_salt(
-            current_app.config.get('OAUTH2_CLIENT_SECRET_SALT_LEN')
+            current_app.config.get('OAUTH2SERVER_CLIENT_SECRET_SALT_LEN')
         )
 
 
@@ -393,7 +393,8 @@ class Token(db.Model):
                 client_id=c.client_id,
                 user_id=user_id,
                 access_token=gen_salt(
-                    current_app.config.get('OAUTH2_TOKEN_PERSONAL_SALT_LEN')
+                    current_app.config.get(
+                        'OAUTH2SERVER_TOKEN_PERSONAL_SALT_LEN')
                 ),
                 expires=None,
                 _scopes=scopes,

--- a/invenio_oauth2server/provider.py
+++ b/invenio_oauth2server/provider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/invenio_oauth2server/templates/invenio_oauth2server/settings/client_view.html
+++ b/invenio_oauth2server/templates/invenio_oauth2server/settings/client_view.html
@@ -1,6 +1,6 @@
 {#
 # This file is part of Invenio.
-# Copyright (C) 2014 CERN.
+# Copyright (C) 2014, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License as
@@ -95,7 +95,7 @@
         <ul>
           <li>client_id (required).</li>
           <li>client_secret (required).</li>
-          <li>grant_type (required, use {% for c in config.OAUTH2_ALLOWED_GRANT_TYPES %}<code>{{c}}</code>{% if not loop.last %}, {% endif %}{% endfor %}).</li>
+          <li>grant_type (required, use {% for c in config.OAUTH2SERVER_ALLOWED_GRANT_TYPES %}<code>{{c}}</code>{% if not loop.last %}, {% endif %}{% endfor %}).</li>
           <li>code (required for grant_type <code>authorization code</code>).</li>
           <li>scope (required for grant_type <code>client_credentials</code>).</li>
           <li>refresh_token (required for grant_type <code>refresh_token</code>).</li>

--- a/invenio_oauth2server/views/server.py
+++ b/invenio_oauth2server/views/server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/invenio_oauth2server/views/server.py
+++ b/invenio_oauth2server/views/server.py
@@ -131,7 +131,7 @@ def access_token():
     return None
 
 
-@blueprint.route('/errors/')
+@blueprint.route('/errors')
 def errors():
     """Error view in case of invalid oauth requests."""
     from oauthlib.oauth2.rfc6749.errors import raise_from_error
@@ -142,14 +142,14 @@ def errors():
         return render_template('invenio_oauth2server/errors.html', error=e)
 
 
-@blueprint.route('/ping/', methods=['GET', 'POST'])
+@blueprint.route('/ping', methods=['GET', 'POST'])
 @oauth2.require_oauth()
 def ping():
     """Test to verify that you have been authenticated."""
     return jsonify(dict(ping="pong"))
 
 
-@blueprint.route('/info/')
+@blueprint.route('/info')
 @oauth2.require_oauth('test:scope')
 def info():
     """Test to verify that you have been authenticated."""
@@ -163,7 +163,7 @@ def info():
         abort(404)
 
 
-@blueprint.route('/invalid/')
+@blueprint.route('/invalid')
 @oauth2.require_oauth('invalid_scope')
 def invalid():
     """Test to verify that you have been authenticated."""

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ install_requires = [
     'Flask-WTF>=0.10.2',
     'Flask>=0.10.1',
     'Invenio-Accounts>=1.0.0a6',
-    'Invenio-DB>=1.0.0a5',
+    'Invenio-DB>=1.0.0a9',
     'SQLAlchemy-Utils[encrypted]>=0.31.0',
     'WTForms-Alchemy>=0.13.3',
     'oauthlib==0.7.2',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def app(request):
         SECRET_KEY='test_key',
         SQLALCHEMY_TRACK_MODIFICATIONS=True,
         SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
-                                          'sqlite:///test.db'),
+                                          'sqlite://'),
         WTF_CSRF_ENABLED=False,
         OAUTHLIB_INSECURE_TRANSPORT=True,
         OAUTH2_CACHE_TYPE='simple',

--- a/tests/test_invenio_oauth2server.py
+++ b/tests/test_invenio_oauth2server.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,6 +27,7 @@
 
 from __future__ import absolute_import, print_function
 
+import pytest
 from flask import Flask
 
 from invenio_oauth2server import InvenioOAuth2Server

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -45,9 +45,9 @@ def test_client_salt(provider_fixture):
 
             client.gen_salt()
             assert len(client.client_id) == \
-                app.config['OAUTH2_CLIENT_ID_SALT_LEN']
+                app.config['OAUTH2SERVER_CLIENT_ID_SALT_LEN']
             assert len(client.client_secret) == \
-                app.config['OAUTH2_CLIENT_SECRET_SALT_LEN']
+                app.config['OAUTH2SERVER_CLIENT_SECRET_SALT_LEN']
 
             db.session.add(client)
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -302,7 +302,7 @@ def web_auth_flow(provider_fixture):
                 assert r.status_code == 200
                 json_resp = json.loads(r.get_data())
                 assert json_resp['client'] == 'confidential'
-                assert json_resp['user'] == app.user1.id
+                assert json_resp['user'] == app.user1_id
                 assert json_resp['scopes'] == [u'test:scope']
 
                 # Access token doesn't provide access to this URL.
@@ -373,7 +373,7 @@ def test_implicit_flow(provider_fixture):
                                        access_token=data['access_token']))
                 assert r.status_code == 200
                 assert json.loads(r.get_data()).get('client') == client_id
-                assert json.loads(r.get_data()).get('user') == app.user1.id
+                assert json.loads(r.get_data()).get('user') == app.user1_id
                 assert json.loads(r.get_data()).get('scopes') \
                     == [u'test:scope']
 
@@ -422,7 +422,7 @@ def test_client_flow(provider_fixture):
                                    access_token=data['access_token']))
             assert r.status_code == 200
             assert json.loads(r.get_data()).get('client') == 'confidential'
-            assert json.loads(r.get_data()).get('user') == app.user1.id
+            assert json.loads(r.get_data()).get('user') == app.user1_id
             assert json.loads(r.get_data()).get('scopes') == [u'test:scope']
 
 
@@ -466,7 +466,7 @@ def test_personal_access_token(provider_fixture):
             r = client.get(
                 url_for('invenio_oauth2server.ping'),
                 query_string="access_token={0}".format(
-                    app.personal_token.access_token)
+                    app.personal_token)
             )
             assert r.status_code == 200
             assert json.loads(r.get_data()) == dict(ping='pong')
@@ -475,7 +475,7 @@ def test_personal_access_token(provider_fixture):
             r = client.get(
                 url_for('invenio_oauth2server.info'),
                 query_string="access_token={0}".format(
-                    app.personal_token.access_token),
+                    app.personal_token),
             )
             assert r.status_code == 401
 
@@ -488,7 +488,7 @@ def test_resource_auth_methods(provider_fixture):
             r = client.get(
                 url_for('invenio_oauth2server.ping'),
                 query_string="access_token={0}".format(
-                    app.personal_token.access_token)
+                    app.personal_token)
             )
             r.status_code == 200
             assert json.loads(r.get_data()) == dict(ping='pong')
@@ -496,7 +496,7 @@ def test_resource_auth_methods(provider_fixture):
             # POST request body
             r = client.post(
                 url_for('invenio_oauth2server.ping'),
-                data=dict(access_token=app.personal_token.access_token),
+                data=dict(access_token=app.personal_token),
             )
             assert r.status_code == 200
             assert json.loads(r.get_data()) == dict(ping='pong')
@@ -506,7 +506,7 @@ def test_resource_auth_methods(provider_fixture):
                 url_for('invenio_oauth2server.ping'),
                 headers=[
                     ("Authorization",
-                     "Bearer {0}".format(app.personal_token.access_token))]
+                     "Bearer {0}".format(app.personal_token))]
                 )
             assert r.status_code == 200
             assert json.loads(r.get_data()) == dict(ping='pong')


### PR DESCRIPTION
* INCOMPATIBLE Changes the config prefix from OAUTH2 to OAUTH2SERVER.
  This is more in line with config prefixes in other Invenio modules.
  (closes #19)

Signed-off-by: Sami Hiltunen <sami.mikael.hiltunen@cern.ch>