### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Invenio-OAuth2Server.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-oauth2server
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/examples/app.py
+++ b/examples/app.py
@@ -44,7 +44,7 @@ Open the admin page to generate a token:
 
 Make a login with:
 
-    username: admin@invenio-software.org
+    username: admin@inveniosoftware.org
     password: 123456
 
 Click on "New token" and compile the form:
@@ -147,12 +147,12 @@ def fixtures():
 def users():
     """Load user fixtures."""
     accounts.datastore.create_user(
-        email='admin@invenio-software.org',
+        email='admin@inveniosoftware.org',
         password='123456',
         active=True,
     )
     accounts.datastore.create_user(
-        email='reader@invenio-software.org',
+        email='reader@inveniosoftware.org',
         password='123456',
         active=True,
     )

--- a/invenio_oauth2server/translations/messages.pot
+++ b/invenio_oauth2server/translations/messages.pot
@@ -8,7 +8,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: invenio-oauth2server 0.1.0.dev20150000\n"
-"Report-Msgid-Bugs-To: info@invenio-software.org\n"
+"Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2015-12-03 16:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ directory = invenio_oauth2server/translations/
 
 [extract_messages]
 copyright_holder = CERN
-msgid_bugs_address = info@invenio-software.org
+msgid_bugs_address = info@inveniosoftware.org
 mapping-file = babel.ini
 output-file = invenio_oauth2server/translations/messages.pot
 

--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
     keywords='invenio OAuth2 server',
     license='GPLv2',
     author='CERN',
-    author_email='info@invenio-software.org',
+    author_email='info@inveniosoftware.org',
     url='https://github.com/inveniosoftware/invenio-oauth2server',
     packages=packages,
     zip_safe=False,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,7 @@ def settings_fixture(app):
     with app.app_context():
         with db.session.begin_nested():
             datastore = app.extensions['security'].datastore
-            datastore.create_user(email='info@invenio-software.org',
+            datastore.create_user(email='info@inveniosoftware.org',
                                   password='tester')
         db.session.commit()
         current_oauth2server.register_scope(Scope('test:scope'))
@@ -130,13 +130,13 @@ def models_fixture(app):
         datastore = app.extensions['security'].datastore
         with db.session.begin_nested():
             test_user = datastore.create_user(
-                email='info@invenio-software.org', password='tester',
+                email='info@inveniosoftware.org', password='tester',
             )
             resource_owner = datastore.create_user(
-                email='resource_owner@invenio-software.org', password='test'
+                email='resource_owner@inveniosoftware.org', password='test'
             )
             consumer = datastore.create_user(
-                email='consumer@invenio-software.org', password='test'
+                email='consumer@inveniosoftware.org', password='test'
             )
 
             # create resource_owner -> client_1
@@ -203,11 +203,11 @@ def provider_fixture(app):
             current_oauth2server.register_scope(Scope('test:scope'))
 
             user1 = datastore.create_user(
-                email='info@invenio-software.org', password='tester',
+                email='info@inveniosoftware.org', password='tester',
                 active=True,
             )
             datastore.create_user(
-                email='abuse@invenio-software.org', password='tester2',
+                email='abuse@inveniosoftware.org', password='tester2',
                 active=True
             )
 
@@ -336,7 +336,7 @@ def resource_fixture(app):
         ))
         with db.session.begin_nested():
             app.user = datastore.create_user(
-                email='info@invenio-software.org', password='tester',
+                email='info@inveniosoftware.org', password='tester',
                 active=True,
             )
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -66,7 +66,7 @@ def parse_redirect(location, parse_fragment=False):
     )
 
 
-def login(test_client, email='info@invenio-software.org', password='tester'):
+def login(test_client, email='info@inveniosoftware.org', password='tester'):
     return test_client.post(
         url_for_security('login'),
         data={

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -135,7 +135,7 @@ def test_access_login_required(resource_fixture):
         assert 'Set-Cookie' in res.headers
         # login
         res = client.post(url_for_security('login'), data=dict(
-            email="info@invenio-software.org",
+            email="info@inveniosoftware.org",
             password="tester"
         ))
         assert 'Set-Cookie' in res.headers

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -556,7 +556,7 @@ def test_settings_index(provider_fixture):
                 data=dict(
                     name='Test',
                     description='Test description',
-                    website='http://invenio-software.org',
+                    website='http://inveniosoftware.org',
                     is_confidential=True,
                     redirect_uris="http://localhost/oauth/authorized/"
                 )
@@ -569,7 +569,7 @@ def test_settings_index(provider_fixture):
                 data=dict(
                     name='Test',
                     description='Test description',
-                    website='http://invenio-software.org',
+                    website='http://inveniosoftware.org',
                     is_confidential=True,
                     redirect_uris="http://example.org/oauth/authorized/"
                 )
@@ -582,7 +582,7 @@ def test_settings_index(provider_fixture):
                 data=dict(
                     name='Test',
                     description='Test description',
-                    website='http://invenio-software.org',
+                    website='http://inveniosoftware.org',
                     is_confidential=True,
                     redirect_uris="https://example.org/oauth/authorized/\n"
                                   "http://localhost:4000/oauth/authorized/"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -114,7 +114,7 @@ def test_client_management(settings_fixture):
                 data=dict(
                     name='Test_Client',
                     description='Test description for Test_Client.',
-                    website='http://invenio-software.org/',
+                    website='http://inveniosoftware.org/',
                     redirect_uris=url_for(
                         'invenio_oauth2server_settings.index', _external=True),
                     is_confditential=1
@@ -150,7 +150,7 @@ def test_client_management(settings_fixture):
                 data=dict(
                     name='Test_Client',
                     description='Test description for Test_Client',
-                    website='http://invenio-software.org/',
+                    website='http://inveniosoftware.org/',
                     redirect_uris='https:/invalid',
                 )
             )


### PR DESCRIPTION
* Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>