### PR TITLE
views: user identity fix

### DIFF
--- a/invenio_oauth2server/views/server.py
+++ b/invenio_oauth2server/views/server.py
@@ -32,6 +32,7 @@ from flask import Blueprint, _request_ctx_stack, abort, current_app, jsonify, \
     redirect, render_template, request
 from flask_babelex import lazy_gettext as _
 from flask_breadcrumbs import register_breadcrumb
+from flask_principal import Identity, identity_changed
 from flask_security import login_required
 from oauthlib.oauth2.rfc6749.errors import InvalidClientError, OAuth2Error
 
@@ -54,6 +55,8 @@ def login_oauth2_user(valid, oauth):
     """Log in a user after having been verified."""
     if valid:
         _request_ctx_stack.top.user = oauth.user
+        identity_changed.send(current_app._get_current_object(),
+                              identity=Identity(oauth.user.id))
 
     return valid, oauth
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ tests_require = [
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
     'pytest>=2.8.0',
+    'six>=1.10.0',
 ]
 
 extras_require = {

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (c) 2015 CERN.
+# Copyright (c) 2015, 2016 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -93,9 +93,7 @@ def test_require_oauth_scopes_allow_anonymous(resource_fixture):
 
 
 def test_rest_extension(resource_fixture):
-    from invenio_oauth2server import InvenioOAuth2ServerREST
     app = resource_fixture
-    InvenioOAuth2ServerREST(app)
     with app.test_client() as client:
         res = client.post(app.url_for_test4resource)
         assert 200 == res.status_code

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2015, 2016 CERN.
+#
+# Invenio is free software; you can redistribute it
+# and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""Test server views."""
+
+from __future__ import absolute_import, print_function
+
+from flask_principal import AnonymousIdentity
+
+
+def test_user_identity_init(resource_fixture):
+    """Test that user identity is loaded properly when a token is used."""
+    app = resource_fixture
+    with app.test_client() as client:
+        # test without token (anonymous user)
+        request_res = client.get(app.url_for_test0resource)
+        assert request_res.status_code == 200
+        assert isinstance(app.identity, AnonymousIdentity)
+
+        # test with token
+        request_res = client.get(app.url_for_test0resource_token)
+        assert request_res.status_code == 200
+        assert app.identity.user.id == app.user_id


### PR DESCRIPTION
* FIX Sets user identity when access token is used on the
  REST API (closes #63).

Signed-off-by: Nicolas Harraudeau <nicolas.harraudeau@cern.ch>