### PR TITLE
global: Flask-WTF upgrade to 0.13

### DIFF
--- a/invenio_oauth2server/forms.py
+++ b/invenio_oauth2server/forms.py
@@ -25,7 +25,7 @@
 """Define forms for generating access tokens and clients."""
 
 from flask_babelex import lazy_gettext as _
-from flask_wtf import Form
+from flask_wtf import FlaskForm as Form
 from oauthlib.oauth2.rfc6749.errors import InsecureTransportError, \
     InvalidRedirectURIError
 from wtforms import fields, validators, widgets

--- a/setup.py
+++ b/setup.py
@@ -80,11 +80,11 @@ install_requires = [
     'Flask-Login>=0.3.0',
     'Flask-OAuthlib>=0.9.3',
     'Flask-Security>=1.7.5',
-    'Flask-WTF>=0.10.2',
+    'Flask-WTF>=0.13',
     'Flask>=0.11.1',
     'SQLAlchemy-Utils[encrypted]>=0.31.0',
     'WTForms-Alchemy>=0.15.0',
-    'invenio-accounts>=1.0.0a14',
+    'invenio-accounts>=1.0.0a15',
     'six>=1.10.0',
     'oauthlib>=1.1.2,<2.0.0',  # FIXME compatiblity issue with 2.x version
 ]


### PR DESCRIPTION
* Updates forms to support Flask-WTF>=0.13. (Closes #82)

Signed-off-by: Leonardo Rossi <leonardo.r@cern.ch>