### PR TITLE
global: oauthlib url encoded characters patch

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -38,3 +38,4 @@ Invenio module that implements OAuth 2 server.
 - Roman Chyla <roman.chyla@gmail.com>
 - Sami Hiltunen <sami.mikael.hiltunen@cern.ch>
 - Tibor Simko <tibor.simko@cern.ch>
+- Alexander Ioannidis <a.ioannidis@cern.ch>

--- a/invenio_oauth2server/config.py
+++ b/invenio_oauth2server/config.py
@@ -61,3 +61,14 @@ A list of allowed response types - allowed values are `code` and `token`.
 - ``code`` is used for authorization_code grant types
 - ``token`` is used for implicit grant types
 """
+
+OAUTH2SERVER_ALLOWED_URLENCODE_CHARACTERS = '=&;:%+~,*@!()/?'
+"""
+A string of special characters that should be valid inside a query string.
+
+.. seealso::
+
+    See :py:func:`monkeypatch_oauthlib_urlencode_chars
+    <invenio_oauth2server.ext.InvenioOAuth2ServerREST.monkeypatch_oauthlib_urlencode_chars>`
+    for a full explanation.
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -128,6 +128,12 @@ def api_app(app):
     return get_method_self(app.wsgi_app.mounts['/api'])
 
 
+@pytest.fixture()
+def api_app_with_test_view(api_app):
+    api_app.add_url_rule('/test', 'test', view_func=lambda: 'OK')
+    return api_app
+
+
 @pytest.fixture
 def settings_fixture(app):
     """Fixture for testing settings views."""


### PR DESCRIPTION
* Patches the `oauthlib.common.urlencoded` set of characters from the
  application configuration, in order to gain control over special
  characters in request query-strings.

Signed-off-by: Alexander Ioannidis <a.ioannidis@cern.ch>