### PR TITLE
installation: unpin Flask-WTF

### DIFF
--- a/invenio_oauth2server/views/settings.py
+++ b/invenio_oauth2server/views/settings.py
@@ -176,7 +176,7 @@ def client_view(client):
         db.session.commit()
         return redirect(url_for('.index'))
 
-    form = ClientForm(request.form, client)
+    form = ClientForm(request.form, obj=client)
     if form.validate_on_submit():
         form.populate_obj(client)
         db.session.commit()

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ install_requires = [
     'Flask-Breadcrumbs>=0.3.0',
     'Flask-Login>=0.3.0',
     'Flask-OAuthlib>=0.9.3',
-    'Flask-WTF==0.13.1',
+    'Flask-WTF>=0.13.1',
     'Flask>=0.11.1',
     'SQLAlchemy-Utils[encrypted]>=0.31.0',
     'WTForms-Alchemy>=0.15.0',


### PR DESCRIPTION
* Fixes wrong form initialization allowing to support Flask-WTF 0.14.
  (closes #105)

Signed-off-by: Lars Holm Nielsen <lars.holm.nielsen@cern.ch>