### PR TITLE
global: addition of JWT

### DIFF
--- a/examples/app.py
+++ b/examples/app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -73,16 +73,16 @@ from __future__ import absolute_import, print_function
 
 import os
 
-from flask import Flask
+from flask import Flask, render_template
 from flask_breadcrumbs import Breadcrumbs
-from flask_mail import Mail
-from flask_menu import Menu
 from flask_oauthlib.provider import OAuth2Provider
 from invenio_accounts import InvenioAccounts
 from invenio_accounts.views import blueprint as accounts_blueprint
 from invenio_admin import InvenioAdmin
+from invenio_assets import InvenioAssets
 from invenio_db import InvenioDB, db
 from invenio_i18n import InvenioI18N
+from invenio_theme import InvenioTheme
 
 from invenio_oauth2server import InvenioOAuth2Server, \
     InvenioOAuth2ServerREST, current_oauth2server, require_api_auth, \
@@ -105,15 +105,16 @@ app.config.update(
     SECURITY_PASSWORD_SCHEMES=['plaintext'],
     SECURITY_DEPRECATED_PASSWORD_SCHEMES=[],
     LOGIN_DISABLED=False,
+    TEMPLATE_AUTO_RELOAD=True,
     SQLALCHEMY_TRACK_MODIFICATIONS=True,
     SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
                                       'sqlite:///example.db'),
     I18N_LANGUAGES=[('fr', 'French'), ('de', 'German'), ('it', 'Italian'),
                     ('es', 'Spanish')],
 )
+InvenioAssets(app)
+InvenioTheme(app)
 InvenioI18N(app)
-Mail(app)
-Menu(app)
 Breadcrumbs(app)
 InvenioDB(app)
 InvenioAdmin(app)
@@ -134,11 +135,17 @@ with app.app_context():
     current_oauth2server.register_scope(Scope('test:scope'))
 
 
-@app.route('/', methods=['GET'])
+@app.route('/jwt', methods=['GET'])
+def jwt():
+    """JWT."""
+    return render_template('jwt.html')
+
+
+@app.route('/', methods=['GET', 'POST'])
 @require_api_auth()
 @require_oauth_scopes('test:scope')
-def example():
-    """Index."""
+def index():
+    """Protected endpoint."""
     return 'hello world'
 
 

--- a/examples/templates/jwt.html
+++ b/examples/templates/jwt.html
@@ -1,0 +1,53 @@
+{%- extends 'invenio_theme/page.html' %}
+
+{%- block page_body %}
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.hideme').hide();
+      $('#correct').on('click', function() {
+        $('.hideme').hide();
+        var $btn = $(this).button('loading');
+        $.ajax({
+          url: '/',
+          method: 'POST',
+          beforeSend: function(request) {
+           request.setRequestHeader("Authorization", 'Bearer ' + $('[name=authorized_token]').val());
+         },
+       }).success(function(response) {
+          $('.alert-success').text(response);
+          $('.alert-success').show();
+          $btn.button('reset');
+       })
+     });
+     $('#wrong').on('click', function() {
+      $('.hideme').hide();
+       var $btn = $(this).button('loading');
+       $.ajax({
+         dataType: 'json',
+         url: '/',
+      }).error(function(response) {
+        var data = jQuery.parseJSON(response.responseText)
+         $('.alert-danger').text(data.message);
+         $('.alert-danger').show();
+         $btn.button('reset');
+      })
+     })
+    })
+</script>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <a class="btn btn-success" href="javascript:void(0)" id="correct">Call API with JWT</a>
+      <a class="btn btn-danger" href="javascript:void(0)" id="wrong">Call API witouth JWT</a>
+    </div>
+    <div class="col-md-12">
+      <hr />
+      <div class="hideme alert alert-danger"></div>
+      <div class="hideme alert alert-success"></div>
+      {% if current_user.is_authenticated %}
+        {{ jwt() | safe }}
+      {% endif %}
+    </div>
+  </div>
+</div>
+{%- endblock %}

--- a/invenio_oauth2server/config.py
+++ b/invenio_oauth2server/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015, 2016 CERN.
+# Copyright (C) 2014, 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -23,6 +23,8 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """OAuth2Server configuration variables."""
+
+from datetime import timedelta
 
 OAUTH2_CACHE_TYPE = 'redis'
 """Type of cache to use for storing the temporary grant token."""
@@ -73,3 +75,96 @@ OAUTH2SERVER_ALLOWED_URLENCODE_CHARACTERS = '=&;:%+~,*@!()/?'
     <invenio_oauth2server.ext.InvenioOAuth2ServerREST.monkeypatch_oauthlib_urlencode_chars>`
     for a full explanation.
 """
+
+OAUTH2SERVER_JWT_ENABLE = True
+"""Enable JWT support.
+
+.. note::
+
+    More details about `JWT <https://jwt.io>`_
+"""
+
+OAUTH2SERVER_JWT_DOM_TOKEN = True
+"""Register JTW context processor.
+
+.. code-block:: html
+
+    {% if current_user.is_authenticated %}
+        {{ jwt() | safe }}
+    {% endif %}
+
+This will generate a ``hidden`` field as follows:
+
+.. code-block:: html
+
+    <input type="hidden" name="authorized_token" value="xxx">
+
+On your API call you can use it with simple javascript, an example using
+``jQuery`` is the following:
+
+.. code-block:: javascript
+
+    $.ajax({
+        url: '/example',
+        method: 'POST',
+        beforeSend: function(request) {
+            request.setRequestHeader(
+                'Authorization',
+                'Bearer ' + $('[name=authorized_token]').val()
+            );
+        },
+    });
+"""
+
+OAUTH2SERVER_JWT_DOM_TOKEN_TEMPLATE = 'invenio_oauth2server/jwt.html'
+"""Template for the context processor."""
+
+OAUTH2SERVER_JWT_SECRET_KEY = None
+"""Secret key for JWT.
+
+.. note::
+
+    If is set to ``None`` it will use the ``SECRET_KEY``.
+"""
+
+OAUTH2SERVER_JWT_AUTH_HEADER = 'Authorization'
+"""Header for the JWT.
+
+.. note::
+
+    Authorization: Bearer xxx
+"""
+
+OAUTH2SERVER_JWT_AUTH_HEADER_TYPE = 'Bearer'
+"""Header Authorization type.
+
+.. note::
+
+    By default the authorization type is ``Bearer`` as recommented by
+    `JWT  <https://jwt.io>`_
+"""
+
+OAUTH2SERVER_JWT_EXPIRATION_DELTA = timedelta(days=1)
+"""Token expiration period for JWT."""
+
+OAUTH2SERVER_JWT_ALOGORITHM = 'HS256'
+"""Set JWT encryption alogirthm.
+
+.. note::
+
+   `Available aglorithms
+   <https://pyjwt.readthedocs.io/en/latest/algorithms.html>`_
+"""
+
+OAUTH2SERVER_JWT_VERYFICATION_FACTORY = 'invenio_oauth2server.utils:' \
+    'jwt_verify_token'
+"""Import path of factory used to verify JWT.
+
+.. note::
+
+    Accepts the request ``headers`` as parameter.
+"""
+
+OAUTH2SERVER_JWT_CREATION_FACTORY = 'invenio_oauth2server.utils:' \
+    'jwt_create_token'
+"""Import path of factory used to generate JWT."""

--- a/invenio_oauth2server/context_processors/__init__.py
+++ b/invenio_oauth2server/context_processors/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,29 +22,6 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-include *.rst
-include *.sh
-include *.txt
-include .dockerignore
-include .editorconfig
-include .lgtm
-include .tx/config
-include LICENSE
-include MAINTAINERS
-include babel.ini
-include docs/requirements.txt
-include pytest.ini
-prune docs/_build
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.py
-recursive-include examples *.txt
-recursive-include examples *.html
-recursive-include invenio_oauth2server *.html
-recursive-include invenio_oauth2server *.mo
-recursive-include invenio_oauth2server *.po
-recursive-include invenio_oauth2server *.pot
-recursive-include invenio_oauth2server *.py
-recursive-include tests *.py
+"""Context processors instances."""
+
+from __future__ import absolute_import, print_function

--- a/invenio_oauth2server/context_processors/jwt.py
+++ b/invenio_oauth2server/context_processors/jwt.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -22,29 +22,22 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-include *.rst
-include *.sh
-include *.txt
-include .dockerignore
-include .editorconfig
-include .lgtm
-include .tx/config
-include LICENSE
-include MAINTAINERS
-include babel.ini
-include docs/requirements.txt
-include pytest.ini
-prune docs/_build
-recursive-include docs *.bat
-recursive-include docs *.py
-recursive-include docs *.rst
-recursive-include docs Makefile
-recursive-include examples *.py
-recursive-include examples *.txt
-recursive-include examples *.html
-recursive-include invenio_oauth2server *.html
-recursive-include invenio_oauth2server *.mo
-recursive-include invenio_oauth2server *.po
-recursive-include invenio_oauth2server *.pot
-recursive-include invenio_oauth2server *.py
-recursive-include tests *.py
+"""JWT context processors."""
+
+from flask import current_app, render_template
+
+from ..proxies import current_oauth2server
+
+
+def jwt_proccessor():
+    """Context processor for jwt."""
+    def jwt():
+        """Context processor function to generate jwt."""
+        token = current_oauth2server.jwt_creation_factory()
+        return render_template(
+            current_app.config['OAUTH2SERVER_JWT_DOM_TOKEN_TEMPLATE'],
+            token=token
+        )
+    return {
+        'jwt': jwt
+    }

--- a/invenio_oauth2server/errors.py
+++ b/invenio_oauth2server/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -24,6 +24,8 @@
 
 """Errors raised by Invenio-OAuth2Server."""
 
+from invenio_rest.errors import RESTException
+
 
 class OAuth2ServerError(Exception):
     """Base class for errors in oauth2server module."""
@@ -36,3 +38,44 @@ class ScopeDoesNotExists(OAuth2ServerError):
         """Initialize exception by storing invalid scope."""
         super(ScopeDoesNotExists, self).__init__(*args, **kwargs)
         self.scope = scope
+
+
+class JWTExtendedException(RESTException):
+    """Base exception for all JWT errors."""
+
+    code = 500
+
+
+class JWTDecodeError(JWTExtendedException):
+    """Exception raised when decoding is failed."""
+
+    code = 400
+    description = 'The JWT token has invalid format.'
+
+
+class JWTInvalidIssuer(JWTExtendedException):
+    """Exception raised when the user is not valid."""
+
+    code = 403
+    description = 'The JWT token is not valid.'
+
+
+class JWTExpiredToken(JWTExtendedException):
+    """Exception raised when JWT is expired."""
+
+    code = 403
+    description = 'The JWT token is expired.'
+
+
+class JWTInvalidHeaderError(JWTExtendedException):
+    """Exception raised when header argument is missing."""
+
+    code = 400
+    description = 'Missing required header argument.'
+
+
+class JWTNoAuthorizationError(JWTExtendedException):
+    """Exception raised when permission denied."""
+
+    code = 400
+    description = "The JWT token is not valid."

--- a/invenio_oauth2server/ext.py
+++ b/invenio_oauth2server/ext.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -31,10 +31,12 @@ import warnings
 
 import oauthlib.common as oauthlib_commmon
 import pkg_resources
+import six
 from flask import request
 from flask_login import current_user
 from flask_oauthlib.contrib.oauth2 import bind_cache_grant, bind_sqlalchemy
 from invenio_db import db
+from werkzeug.utils import cached_property, import_string
 
 from . import config
 from .models import Client, OAuthUserProxy, Scope
@@ -106,6 +108,33 @@ class _OAuth2ServerState(object):
         for ep in pkg_resources.iter_entry_points(group=entry_point_group):
             self.register_scope(ep.load())
 
+    def load_obj_or_import_string(self, value):
+        """Import string or return object.
+
+        :params value: Import path or class object to instantiate.
+        :params default: Default object to return if the import fails.
+        :returns: The imported object.
+        """
+        imp = self.app.config.get(value)
+        if isinstance(imp, six.string_types):
+            return import_string(imp)
+        elif imp:
+            return imp
+
+    @cached_property
+    def jwt_veryfication_factory(self):
+        """Load default JWT veryfication factory."""
+        return self.load_obj_or_import_string(
+            'OAUTH2SERVER_JWT_VERYFICATION_FACTORY'
+        )
+
+    @cached_property
+    def jwt_creation_factory(self):
+        """Load default JWT creation factory."""
+        return self.load_obj_or_import_string(
+            'OAUTH2SERVER_JWT_CREATION_FACTORY'
+        )
+
 
 class InvenioOAuth2Server(object):
     """Invenio-OAuth2Server extension."""
@@ -128,6 +157,12 @@ class InvenioOAuth2Server(object):
         """
         self.init_config(app)
         state = _OAuth2ServerState(app, entry_point_group=entry_point_group)
+
+        if app.config['OAUTH2SERVER_JWT_DOM_TOKEN']:
+            from invenio_oauth2server.context_processors.jwt import \
+                jwt_proccessor
+            app.context_processor(jwt_proccessor)
+
         app.extensions['invenio-oauth2server'] = state
         return state
 
@@ -144,6 +179,10 @@ class InvenioOAuth2Server(object):
             'OAUTH2SERVER_SETTINGS_TEMPLATE',
             app.config.get('SETTINGS_TEMPLATE',
                            'invenio_oauth2server/settings/base.html'))
+        app.config.setdefault(
+            'OAUTH2SERVER_JWT_SECRET_KEY',
+            app.config.get('OAUTH2SERVER_JWT_SECRET_KEY',
+                           app.config.get('SECRET_KEY')))
 
         for k in dir(config):
             if k.startswith('OAUTH2SERVER_') or k.startswith('OAUTH2_'):

--- a/invenio_oauth2server/templates/invenio_oauth2server/jwt.html
+++ b/invenio_oauth2server/templates/invenio_oauth2server/jwt.html
@@ -1,0 +1,20 @@
+{#
+# This file is part of Invenio.
+# Copyright (C) 2017 CERN.
+#
+# Invenio is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# Invenio is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Invenio; if not, write to the Free Software Foundation, Inc.,
+# 59 Temple Place, Suite 330, Boston, MA 02111-1307, USA.
+#}
+
+<input type='hidden' name='authorized_token' value='{{ token }}' />

--- a/invenio_oauth2server/utils.py
+++ b/invenio_oauth2server/utils.py
@@ -22,11 +22,19 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-"""Utility function for handling SECRET_KEY changes."""
-from flask import current_app
-from invenio_db.utils import rebuild_encrypted_properties
+"""Utility functions."""
 
-from invenio_oauth2server.models import Token
+import uuid
+from datetime import datetime
+
+from flask import abort, current_app
+from flask_login import current_user
+from invenio_db.utils import rebuild_encrypted_properties
+from jwt import DecodeError, ExpiredSignatureError, decode, encode
+
+from .errors import JWTDecodeError, JWTExpiredToken, JWTInvalidHeaderError, \
+    JWTInvalidIssuer
+from .models import Token
 
 
 def rebuild_access_tokens(old_key):
@@ -39,3 +47,99 @@ def rebuild_access_tokens(old_key):
     current_app.logger.info('rebuilding Token.access_token...')
     rebuild_encrypted_properties(old_key, Token,
                                  ['access_token', 'refresh_token'])
+
+
+def jwt_authorization_header(headers):
+    """Read the authorization token from the headers.
+
+    :param dict headers: The request headers.
+    :returns: The token.
+    :rtype: str
+    """
+    code = headers.get(
+        current_app.config['OAUTH2SERVER_JWT_AUTH_HEADER']
+    )
+    if code is None:
+        raise JWTInvalidHeaderError
+    return code
+
+
+def jwt_verify_token(headers):
+    """Verify the JWT token.
+
+    :param dict headers: The request headers.
+    :returns: The token data.
+    :rtype: dict
+    """
+    # Get the token from headers
+    token = jwt_authorization_header(headers)
+    # Get the prefix and the token
+    prefix, code = token.split()
+    # Check if the type matches
+    if prefix != current_app.config['OAUTH2SERVER_JWT_AUTH_HEADER_TYPE']:
+        raise JWTInvalidHeaderError
+    # Get the token data
+    decode = jwt_decode_token(code)
+    # Check the integrity of the user
+    if current_user.get_id() != decode.get('sub'):
+        raise JWTInvalidIssuer
+    return decode
+
+
+def jwt_create_token(user_id=None, additional_data=None):
+    """Encode the JWT token.
+
+    :param int user_id: Addition of user_id.
+    :param dict additional_data: Additional information for the token.
+    :returns: The encoded token.
+    :rtype: str
+
+    .. note::
+        Definition of the JWT claims:
+
+        * exp: ((Expiration Time) expiration time of the JWT.
+        * sub: (subject) the principal that is the subject of the JWT.
+        * jti: (JWT ID) UID for the JWT.
+    """
+    # Create an ID
+    uid = str(uuid.uuid4())
+    # The time in UTC now
+    now = datetime.utcnow()
+    # Build the token data
+    token_data = {
+        'exp': now + current_app.config['OAUTH2SERVER_JWT_EXPIRATION_DELTA'],
+        'sub': user_id or current_user.get_id(),
+        'jti': uid,
+    }
+    # Add any additional data to the token
+    if additional_data is not None:
+        token_data.update(additional_data)
+
+    # Encode the token and send it back
+    encoded_token = encode(
+        token_data,
+        current_app.config['OAUTH2SERVER_JWT_SECRET_KEY'],
+        current_app.config['OAUTH2SERVER_JWT_ALOGORITHM']
+    ).decode('utf-8')
+    return encoded_token
+
+
+def jwt_decode_token(token):
+    """Decode the JWT token.
+
+    :param str token: Additional information for the token.
+    :returns: The token data.
+    :rtype: dict
+    """
+    try:
+        return decode(
+            token,
+            current_app.config['OAUTH2SERVER_JWT_SECRET_KEY'],
+            algorithms=[
+                current_app.config['OAUTH2SERVER_JWT_ALOGORITHM']
+            ]
+        )
+    except DecodeError:
+        raise JWTDecodeError
+    except ExpiredSignatureError:
+        raise JWTExpiredToken

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def app(request):
             LOGIN_DISABLED=False,
             MAIL_SUPPRESS_SEND=True,
             OAUTH2_CACHE_TYPE='simple',
+            OAUTH2SERVER_JWT_ENABLE=False,
             OAUTHLIB_INSECURE_TRANSPORT=True,
             SECRET_KEY='CHANGE_ME',
             SECURITY_DEPRECATED_PASSWORD_SCHEMES=[],

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (c) 2015, 2016 CERN.
+# Copyright (c) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -24,7 +24,13 @@
 
 """OAuth2Server decorators test cases."""
 
+from datetime import datetime
+
 from flask import url_for
+
+from invenio_oauth2server.utils import jwt_authorization_header, \
+    jwt_create_token, jwt_decode_token, jwt_verify_token, \
+    rebuild_access_tokens
 
 
 def test_require_api_auth_oauthlib_urldecode_issue(resource_fixture):
@@ -144,3 +150,75 @@ def test_access_login_required(resource_fixture):
         res = client.post(app.url_for_test3resource)
         assert 401 == res.status_code
         assert 'Set-Cookie' not in res.headers
+
+
+def test_jwt_client(resource_fixture):
+    """Test client."""
+    app = resource_fixture
+    # Enable JWT
+    app.config['OAUTH2SERVER_JWT_ENABLE'] = True
+    with app.test_client() as client:
+        # Try to access to authentication required zone
+        res = client.post(app.url_for_test3resource)
+        assert 401 == res.status_code
+        # Login
+        res = client.post(url_for('security.login'), data=dict(
+            email='info@inveniosoftware.org',
+            password='tester'
+        ))
+        assert 'Set-Cookie' in res.headers
+        # Try to access to without a JWT
+        res = client.post(app.url_for_test3resource)
+        assert 400 == res.status_code
+
+        # Generate a token
+        token = jwt_create_token()
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Bearer {}'.format(token))
+            ]
+        )
+        assert 200 == res.status_code
+
+        # Try with invalid user
+        token = jwt_create_token(user_id=-20)
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Bearer {}'.format(token))
+            ]
+        )
+        assert 403 == res.status_code
+        assert 'The JWT token is not valid.' in res.get_data()
+
+        # Try to access with expired token
+        extra = dict(
+            exp=datetime(1970, 1, 1),
+        )
+        # Create token
+        token = jwt_create_token(additional_data=extra)
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Bearer {0}'.format(token))
+            ]
+        )
+        assert 403 == res.status_code
+        assert 'The JWT token is expired.' in res.get_data()
+
+        # Not correct Schema
+        # Generate a token
+        token = jwt_create_token()
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Avengers {}'.format(token))
+            ]
+        )
+        assert 400 == res.status_code
+        assert 'Missing required header argument.' in res.get_data()

--- a/tests/test_invenio_oauth2server.py
+++ b/tests/test_invenio_oauth2server.py
@@ -110,3 +110,12 @@ def test_alembic(app):
 
         assert not ext.alembic.compare_metadata()
         ext.alembic.downgrade(target='96e796392533')
+
+
+def test_jwt_init():
+    """Test extension initialization."""
+    app = Flask('testapp')
+    ext = InvenioOAuth2Server(app)
+    assert 'invenio-oauth2server' in app.extensions
+    assert ext.app.config.get('OAUTH2SERVER_JWT_SECRET_KEY') == \
+        ext.app.config.get('SECRET_KEY')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,12 +20,18 @@
 """Test case for rebuilding access tokens."""
 
 import sys
+from datetime import datetime
 
 import pytest
+from flask import url_for
 from invenio_db import db
 
+from invenio_oauth2server.errors import JWTDecodeError, JWTExpiredToken, \
+    JWTInvalidHeaderError, JWTInvalidIssuer
 from invenio_oauth2server.models import Token
-from invenio_oauth2server.utils import rebuild_access_tokens
+from invenio_oauth2server.utils import jwt_authorization_header, \
+    jwt_create_token, jwt_decode_token, jwt_verify_token, \
+    rebuild_access_tokens
 
 
 def test_rebuilding_access_tokens(models_fixture):
@@ -55,3 +61,35 @@ def test_rebuilding_access_tokens(models_fixture):
                                                   tokens_after)):
             assert token_before.access_token == token_after.access_token
             assert token_before.refresh_token == token_after.refresh_token
+
+
+def test_jwt_token(app):
+    """Test jwt creation."""
+    with app.app_context():
+        # Extra parameters
+        extra = dict(
+            defenders=['jessica', 'luke', 'danny', 'matt']
+        )
+        # Create token normally
+        token = jwt_create_token(user_id=1, additional_data=extra)
+        decode = jwt_decode_token(token)
+        # Decode
+        assert 'jessica' in decode.get('defenders')
+        assert 1 == decode.get('sub')
+
+
+def test_jwt_expired_token(app):
+    """Test jwt creation."""
+    with app.app_context():
+        # Extra parameters
+        extra = dict(
+            exp=datetime(1970, 1, 1),
+        )
+        # Create token
+        token = jwt_create_token(user_id=1, additional_data=extra)
+        # Decode
+        with pytest.raises(JWTExpiredToken):
+            jwt_decode_token(token)
+        # Random token
+        with pytest.raises(JWTDecodeError):
+            jwt_decode_token('Roadster SV')


### PR DESCRIPTION
* Adds support for JWT (jwt.io), which is enabled by default. All the
  protected endpoints ``require_api_auth`` will be automatically
  check for JWT in the headers. A token can be generated by using the
  ``{{ jwt() | clean }}`` context processor in jinja templates and can
  be send with each API request.

Signed-off-by: Harris Tzovanakis <me@drjova.com>