### PR TITLE
global: addition of JWT

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -41,6 +41,7 @@ recursive-include docs *.rst
 recursive-include docs Makefile
 recursive-include examples *.py
 recursive-include examples *.txt
+recursive-include examples *.html
 recursive-include invenio_oauth2server *.html
 recursive-include invenio_oauth2server *.mo
 recursive-include invenio_oauth2server *.po

--- a/examples/app.py
+++ b/examples/app.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -73,16 +73,16 @@ from __future__ import absolute_import, print_function
 
 import os
 
-from flask import Flask
+from flask import Flask, render_template
 from flask_breadcrumbs import Breadcrumbs
-from flask_mail import Mail
-from flask_menu import Menu
 from flask_oauthlib.provider import OAuth2Provider
 from invenio_accounts import InvenioAccounts
 from invenio_accounts.views import blueprint as accounts_blueprint
 from invenio_admin import InvenioAdmin
+from invenio_assets import InvenioAssets
 from invenio_db import InvenioDB, db
 from invenio_i18n import InvenioI18N
+from invenio_theme import InvenioTheme
 
 from invenio_oauth2server import InvenioOAuth2Server, \
     InvenioOAuth2ServerREST, current_oauth2server, require_api_auth, \
@@ -105,15 +105,16 @@ app.config.update(
     SECURITY_PASSWORD_SCHEMES=['plaintext'],
     SECURITY_DEPRECATED_PASSWORD_SCHEMES=[],
     LOGIN_DISABLED=False,
+    TEMPLATE_AUTO_RELOAD=True,
     SQLALCHEMY_TRACK_MODIFICATIONS=True,
     SQLALCHEMY_DATABASE_URI=os.getenv('SQLALCHEMY_DATABASE_URI',
                                       'sqlite:///example.db'),
     I18N_LANGUAGES=[('fr', 'French'), ('de', 'German'), ('it', 'Italian'),
                     ('es', 'Spanish')],
 )
+InvenioAssets(app)
+InvenioTheme(app)
 InvenioI18N(app)
-Mail(app)
-Menu(app)
 Breadcrumbs(app)
 InvenioDB(app)
 InvenioAdmin(app)
@@ -134,11 +135,17 @@ with app.app_context():
     current_oauth2server.register_scope(Scope('test:scope'))
 
 
-@app.route('/', methods=['GET'])
+@app.route('/jwt', methods=['GET'])
+def jwt():
+    """JWT."""
+    return render_template('jwt.html')
+
+
+@app.route('/', methods=['GET', 'POST'])
 @require_api_auth()
 @require_oauth_scopes('test:scope')
-def example():
-    """Index."""
+def index():
+    """Protected endpoint."""
     return 'hello world'
 
 

--- a/examples/templates/jwt.html
+++ b/examples/templates/jwt.html
@@ -1,0 +1,53 @@
+{%- extends 'invenio_theme/page.html' %}
+
+{%- block page_body %}
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.hideme').hide();
+      $('#correct').on('click', function() {
+        $('.hideme').hide();
+        var $btn = $(this).button('loading');
+        $.ajax({
+          url: '/',
+          method: 'POST',
+          beforeSend: function(request) {
+           request.setRequestHeader("Authorization", 'Bearer ' + $('[name=authorized_token]').val());
+         },
+       }).success(function(response) {
+          $('.alert-success').text(response);
+          $('.alert-success').show();
+          $btn.button('reset');
+       })
+     });
+     $('#wrong').on('click', function() {
+      $('.hideme').hide();
+       var $btn = $(this).button('loading');
+       $.ajax({
+         dataType: 'json',
+         url: '/',
+      }).error(function(response) {
+        var data = jQuery.parseJSON(response.responseText)
+         $('.alert-danger').text(data.message);
+         $('.alert-danger').show();
+         $btn.button('reset');
+      })
+     })
+    })
+</script>
+<div class="container">
+  <div class="row">
+    <div class="col-md-12">
+      <a class="btn btn-success" href="javascript:void(0)" id="correct">Call API with JWT</a>
+      <a class="btn btn-danger" href="javascript:void(0)" id="wrong">Call API witouth JWT</a>
+    </div>
+    <div class="col-md-12">
+      <hr />
+      <div class="hideme alert alert-danger"></div>
+      <div class="hideme alert alert-success"></div>
+      {% if current_user.is_authenticated %}
+        {{ jwt() | safe }}
+      {% endif %}
+    </div>
+  </div>
+</div>
+{%- endblock %}

--- a/invenio_oauth2server/config.py
+++ b/invenio_oauth2server/config.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2014, 2015, 2016 CERN.
+# Copyright (C) 2014, 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -23,6 +23,8 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 """OAuth2Server configuration variables."""
+
+from datetime import timedelta
 
 OAUTH2_CACHE_TYPE = 'redis'
 """Type of cache to use for storing the temporary grant token."""
@@ -72,4 +74,28 @@ OAUTH2SERVER_ALLOWED_URLENCODE_CHARACTERS = '=&;:%+~,*@!()/?'
     See :py:func:`monkeypatch_oauthlib_urlencode_chars
     <invenio_oauth2server.ext.InvenioOAuth2ServerREST.monkeypatch_oauthlib_urlencode_chars>`
     for a full explanation.
+"""
+
+OAUTH2SERVER_JWT_AUTH_HEADER = 'Authorization'
+"""Header for the JWT.
+
+.. note::
+
+    Authorization: Bearer xxx
+"""
+
+OAUTH2SERVER_JWT_AUTH_HEADER_TYPE = 'Bearer'
+"""Header Authorization type.
+
+.. note::
+
+    By default the authorization type is ``Bearer`` as recommented by
+    `JWT  <https://jwt.io>`_
+"""
+
+OAUTH2SERVER_JWT_VERYFICATION_FACTORY = 'invenio_oauth2server.utils:' \
+    'jwt_verify_token'
+"""Import path of factory used to verify JWT.
+
+The ``request.headers`` should be passed as parameter.
 """

--- a/invenio_oauth2server/decorators.py
+++ b/invenio_oauth2server/decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015, 2016 CERN.
+# Copyright (C) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -27,12 +27,13 @@
 import sys
 from functools import wraps
 
-from flask import abort, request
+from flask import abort, current_app, request
 from flask_login import current_user
 from six import reraise
 from werkzeug.exceptions import Unauthorized
 
 from .provider import oauth2
+from .proxies import current_oauth2server
 
 
 def require_api_auth(allow_anonymous=False):
@@ -49,6 +50,10 @@ def require_api_auth(allow_anonymous=False):
         def decorated(*args, **kwargs):
             """Require OAuth 2.0 Authentication."""
             if current_user.is_authenticated:
+                if current_app.config['ACCOUNTS_JWT_ENABLE']:
+                    # Verify the token
+                    current_oauth2server.jwt_veryfication_factory(
+                        request.headers)
                 # fully logged in with normal session
                 return f(*args, **kwargs)
             else:

--- a/invenio_oauth2server/errors.py
+++ b/invenio_oauth2server/errors.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2015 CERN.
+# Copyright (C) 2015, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -24,6 +24,12 @@
 
 """Errors raised by Invenio-OAuth2Server."""
 
+from __future__ import absolute_import, print_function
+
+import json
+
+from werkzeug.exceptions import HTTPException
+
 
 class OAuth2ServerError(Exception):
     """Base class for errors in oauth2server module."""
@@ -36,3 +42,75 @@ class ScopeDoesNotExists(OAuth2ServerError):
         """Initialize exception by storing invalid scope."""
         super(ScopeDoesNotExists, self).__init__(*args, **kwargs)
         self.scope = scope
+
+
+class JWTExtendedException(HTTPException):
+    """Base exception for all JWT errors."""
+
+    errors = None
+
+    def __init__(self, errors=None, **kwargs):
+        """Initialize JWTExtendedException."""
+        super(JWTExtendedException, self).__init__(**kwargs)
+
+        if errors is not None:
+            self.errors = errors
+
+    def get_errors(self):
+        """Get errors.
+
+        :returns: A list containing a dictionary representing the errors.
+        """
+        return [e.to_dict() for e in self.errors] if self.errors else None
+
+    def get_body(self, environ=None):
+        """Get the request body."""
+        body = dict(
+            status=self.code,
+            message=self.description,
+        )
+
+        errors = self.get_errors()
+        if self.errors:
+            body['errors'] = errors
+
+        return json.dumps(body)
+
+    def get_headers(self, environ=None):
+        """Get a list of headers."""
+        return [('Content-Type', 'application/json')]
+
+
+class JWTDecodeError(JWTExtendedException):
+    """Exception raised when decoding is failed."""
+
+    code = 400
+    description = 'The JWT token has invalid format.'
+
+
+class JWTInvalidIssuer(JWTExtendedException):
+    """Exception raised when the user is not valid."""
+
+    code = 403
+    description = 'The JWT token is not valid.'
+
+
+class JWTExpiredToken(JWTExtendedException):
+    """Exception raised when JWT is expired."""
+
+    code = 403
+    description = 'The JWT token is expired.'
+
+
+class JWTInvalidHeaderError(JWTExtendedException):
+    """Exception raised when header argument is missing."""
+
+    code = 400
+    description = 'Missing required header argument.'
+
+
+class JWTNoAuthorizationError(JWTExtendedException):
+    """Exception raised when permission denied."""
+
+    code = 400
+    description = "The JWT token is not valid."

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,9 @@ tests_require = [
     'SQLAlchemy-Continuum>=1.2.1',
     'check-manifest>=0.25',
     'coverage>=4.0',
-    'invenio-i18n>=1.0.0b2',
+    'invenio-assets>=1.0.0b6',
+    'invenio-i18n>=1.0.0b3',
+    'invenio-theme>=1.0.0b2',
     'isort>=4.2.2',
     'mock>=1.3.0',
     'pydocstyle>=1.0.0',
@@ -80,16 +82,18 @@ setup_requires = [
 
 install_requires = [
     'Flask-BabelEx>=0.9.2',
-    'Flask-Breadcrumbs>=0.3.0',
+    'Flask-Breadcrumbs>=0.4.0',
     'Flask-Login>=0.3.0',
     'Flask-OAuthlib>=0.9.3',
     'Flask-WTF>=0.13.1',
     'Flask>=0.11.1',
+    'future>=0.16.0',
+    'invenio-accounts>=1.0.0b4',
+    'oauthlib>=1.1.2,!=2.0.0',
+    'pyjwt>=1.5.0',
+    'six>=1.10.0',
     'SQLAlchemy-Utils[encrypted]>=0.31.0',
     'WTForms-Alchemy>=0.15.0',
-    'invenio-accounts>=1.0.0b3',
-    'oauthlib>=1.1.2,!=2.0.0',
-    'six>=1.10.0',
 ]
 
 packages = find_packages()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,7 @@ def app(request):
             LOGIN_DISABLED=False,
             MAIL_SUPPRESS_SEND=True,
             OAUTH2_CACHE_TYPE='simple',
+            ACCOUNTS_JWT_ENABLE=False,
             OAUTHLIB_INSECURE_TRANSPORT=True,
             SECRET_KEY='CHANGE_ME',
             SECURITY_DEPRECATED_PASSWORD_SCHEMES=[],

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (c) 2015, 2016 CERN.
+# Copyright (c) 2015, 2016, 2017 CERN.
 #
 # Invenio is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -24,7 +24,12 @@
 
 """OAuth2Server decorators test cases."""
 
+from datetime import datetime
+
 from flask import url_for
+from invenio_accounts.proxies import current_accounts
+
+from invenio_oauth2server.utils import rebuild_access_tokens
 
 
 def test_require_api_auth_oauthlib_urldecode_issue(resource_fixture):
@@ -144,3 +149,91 @@ def test_access_login_required(resource_fixture):
         res = client.post(app.url_for_test3resource)
         assert 401 == res.status_code
         assert 'Set-Cookie' not in res.headers
+
+
+def test_jwt_client(resource_fixture):
+    """Test client."""
+    app = resource_fixture
+    # Enable JWT
+    app.config['ACCOUNTS_JWT_ENABLE'] = True
+    with app.test_client() as client:
+
+        # Try to access to authentication required zone
+        res = client.post(app.url_for_test3resource)
+        assert 401 == res.status_code
+
+        # Login
+        res = client.post(url_for('security.login'), data=dict(
+            email='info@inveniosoftware.org',
+            password='tester'
+        ))
+        assert 'Set-Cookie' in res.headers
+        # Try to access to without a JWT
+        res = client.post(app.url_for_test3resource)
+        assert 400 == res.status_code
+
+        # Generate a token
+        token = current_accounts.jwt_creation_factory()
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Bearer {}'.format(token))
+            ]
+        )
+        assert 200 == res.status_code
+
+        # Try with invalid user
+        token = current_accounts.jwt_creation_factory(user_id=-20)
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Bearer {}'.format(token))
+            ]
+        )
+        assert 403 == res.status_code
+        assert 'The JWT token is not valid.' in res.get_data(as_text=True)
+
+        # Try to access with expired token
+        extra = dict(
+            exp=datetime(1970, 1, 1),
+        )
+        # Create token
+        token = current_accounts.jwt_creation_factory(additional_data=extra)
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Bearer {0}'.format(token))
+            ]
+        )
+        assert 'The JWT token is expired.' in res.get_data(as_text=True)
+
+        # Not correct Schema
+        # Generate a token
+        token = current_accounts.jwt_creation_factory()
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('Authorization', 'Avengers {}'.format(token))
+            ]
+        )
+        assert 400 == res.status_code
+        assert 'Missing required header argument.' in res.get_data(
+            as_text=True)
+
+        # Check different header type
+        app.config['OAUTH2SERVER_JWT_AUTH_HEADER'] = 'X-Travis-Mark-XLII'
+        app.config['OAUTH2SERVER_JWT_AUTH_HEADER_TYPE'] = None
+        # Create token
+        token = current_accounts.jwt_creation_factory()
+        # Make the request
+        res = client.post(
+            app.url_for_test3resource,
+            headers=[
+                ('X-Travis-Mark-XLII', '{0}'.format(token))
+            ]
+        )
+        assert 200 == res.status_code


### PR DESCRIPTION
* Adds support for JWT (jwt.io), which is enabled by default. All the
  protected endpoints ``require_api_auth`` will be automatically
  check for JWT in the headers. A token can be generated by using the
  ``{{ jwt() }}`` context processor in jinja templates or from
  ``invenio_accounts.utils:jwt_create_token``. The generated token must
  be sent by each request.

Signed-off-by: Harris Tzovanakis <me@drjova.com>