### PR TITLE
views: don't render scopes if empty

### DIFF
--- a/invenio_oauth2server/views/settings.py
+++ b/invenio_oauth2server/views/settings.py
@@ -222,6 +222,9 @@ def token_new():
         session['show_personal_access_token'] = True
         return redirect(url_for(".token_view", token_id=t.id))
 
+    if len(current_oauth2server.scope_choices()) == 0:
+        del(form.scopes)
+
     return render_template(
         "invenio_oauth2server/settings/token_new.html",
         form=form,
@@ -250,6 +253,9 @@ def token_view(token):
         token.client.name = form.data['name']
         token.scopes = form.data['scopes']
         db.session.commit()
+
+    if len(current_oauth2server.scope_choices()) == 0:
+        del(form.scopes)
 
     return render_template(
         "invenio_oauth2server/settings/token_view.html",


### PR DESCRIPTION
* ADDS check to delete the scopes field from the token form
  so that it doesn't render if there are no scope choices.
  (closes https://github.com/inveniosoftware/invenio-oauth2server/issues/121)

Signed-off-by: Dinos Kousidis <konstantinos.kousidis@cern.ch>