### PR TITLE
Unpin+bump oauthlib to fix AccessDenied errors

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ install_requires = [
     'Flask>=0.11.1',
     'future>=0.16.0',
     'invenio-accounts>=1.0.0b7',
-    'oauthlib>=1.1.2,<2.0.0',
+    'oauthlib>=1.1.2,!=2.0.0,!=2.0.3,!=2.0.4,!=2.0.5',
     'pyjwt>=1.5.0',
     'six>=1.10.0',
     'SQLAlchemy-Utils[encrypted]>=0.31.0',


### PR DESCRIPTION
* Unpin+bump flask-oauthlib version to fix AccessDenied errors
  Versions 2.0.1 and 2.0.2 work fine.
  AccessDenied errors were introduced in 2.0.3 and fixed in 2.0.5.
  However, 2.0.5 contains breaking changes, hence 2.0.6.
  (closes #163)

Signed-off-by: Harri Hirvonsalo <harri.hirvonsalo@cern.ch>