### PR TITLE
dependencies: oauthlib<3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ install_requires = [
     'Flask>=0.11.1',
     'future>=0.16.0',
     'invenio-accounts>=1.0.0',
-    'oauthlib>=1.1.2,!=2.0.0,!=2.0.3,!=2.0.4,!=2.0.5',
+    'oauthlib>=1.1.2,!=2.0.0,!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0',
     'pyjwt>=1.5.0',
     'six>=1.10.0',
     'SQLAlchemy-Utils[encrypted]>=0.33.0',


### PR DESCRIPTION
Few hours ago they released version 3 of oauthlib. flask-oauthlib has requirements `oauthlib!=2.0.3,!=2.0.4,!=2.0.5,<3.0.0,>=1.1.2`,  so various setups break.