### PR TITLE
forms: fix for Client Type select

### DIFF
--- a/invenio_oauth2server/forms.py
+++ b/invenio_oauth2server/forms.py
@@ -154,9 +154,9 @@ class ClientForm(ClientFormBase):
             'select public if your application cannot (e.g. a browser-based '
             'JavaScript application). If you select public, your application '
             'MUST validate the redirect URI.'),
-        coerce=bool,
-        choices=[(True, _('Confidential')), (False, _('Public'))],
-        default=True,
+        coerce=lambda x: False if x == "False" else bool(x),
+        choices=[("True", _('Confidential')), ("False", _('Public'))],
+        default="True",
         widget=widget,
     )
 

--- a/invenio_oauth2server/theme/semantic/form_styling.py
+++ b/invenio_oauth2server/theme/semantic/form_styling.py
@@ -19,14 +19,14 @@ class SelectSUI(object):
     def __call__(self, field, **kwargs):
         """Render select field."""
         html = [u'<div class="ui fluid selection dropdown">']
-        html.append(u'<input type="hidden" name="client_type">')
+        html.append(u'<input type="hidden" name="{0}">'.format(field.name))
         html.append(u'<i class="dropdown icon"></i>')
         items_html = []
         default_text_html = []
         for val, label, selected in field.iter_choices():
             if selected:
                 default_text_html = [
-                    u'<div class="default text">{0}</div><div class="menu">'
+                    u'<div class="text">{0}</div><div class="menu">'
                     .format(label)
                 ]
             items_html.append(self.render_option(val, label, selected))


### PR DESCRIPTION
- fix the issue when we choose Client Type: Confidential or Public. 
    - When a value is False, [wtforms](https://github.com/wtforms/wtforms/blob/c1906fbe37f137e9b79d499313432246400c69d5/wtforms/widgets/core.py#L69) doesnt render value="False" for the html elements.
    - Fix the coerce for is_confidential, in html our values are strings, so when in python we do bool("False") we get True.
- changed hardcoded client_type to field.name
- closes #225