### PR TITLE
ext: replace pkg_resources

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-          python-version: [3.6, 3.7, 3.8]
+          python-version: [3.6, 3.7, 3.8, 3.9]
           requirements-level: [min, pypi]
           db-service: [postgresql9, postgresql11, mysql5, mysql8]
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,6 +1,7 @@
 ..
     This file is part of Invenio.
     Copyright (C) 2015-2018 CERN.
+    Copyright (C) 2022 RERO.
 
     Invenio is free software; you can redistribute it and/or modify it
     under the terms of the MIT License; see LICENSE file for more details.
@@ -35,11 +36,15 @@ Validators
 .. automodule:: invenio_oauth2server.validators
    :members:
 
-Proxies
--------
+..
+   Proxies is not working because of current_app throws an exception:
+   'Working outside of application context'.
+.. Proxies
+.. -------
 
-.. automodule:: invenio_oauth2server.proxies
-   :members:
+.. .. automodule:: invenio_oauth2server.proxies
+..    :members:
+
 
 Errors
 ------

--- a/invenio_oauth2server/errors.py
+++ b/invenio_oauth2server/errors.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 RERO.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -60,7 +61,7 @@ class JWTExtendedException(HTTPException):
 
         return json.dumps(body)
 
-    def get_headers(self, environ=None):
+    def get_headers(self, environ=None, scope=None):
         """Get a list of headers."""
         return [('Content-Type', 'application/json')]
 

--- a/invenio_oauth2server/ext.py
+++ b/invenio_oauth2server/ext.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 RERO.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -13,8 +14,8 @@ from __future__ import absolute_import, print_function
 import os
 import warnings
 
+import importlib_metadata
 import oauthlib.common as oauthlib_commmon
-import pkg_resources
 import six
 from flask import abort, request
 from flask_login import current_user
@@ -88,7 +89,9 @@ class _OAuth2ServerState(object):
 
         :param entry_point_group: The entrypoint group name to load plugins.
         """
-        for ep in pkg_resources.iter_entry_points(group=entry_point_group):
+        for ep in set(importlib_metadata.entry_points(
+            group=entry_point_group
+        )):
             self.register_scope(ep.load())
 
     def load_obj_or_import_string(self, value):

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -3,6 +3,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 RERO.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -26,6 +27,6 @@ python -m check_manifest --ignore ".*-requirements.txt"
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --env)"
 python -m pytest
-python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 tests_exit_code=$?
+python -m sphinx.cmd.build -qnNW -b doctest docs docs/_build/doctest
 exit "$tests_exit_code"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
+# Copyright (C) 2022 RERO.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -24,7 +25,7 @@ extras_require = {
         'invenio-admin>=1.2.1'
     ],
     'docs': [
-        'Sphinx>=2,<3',
+        'Sphinx>=4.2.0',
     ],
     'redis': [
         'redis>=2.10.5',
@@ -66,6 +67,7 @@ install_requires = [
     'requests-oauthlib>=1.1.0,<1.2.0',
     'WTForms-Alchemy>=0.15.0',
     'WTForms>=2.3.3,<3.0.0',
+    'importlib_metadata>=4.4'
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* Replaces `pkg_resources` with `importlib_metadata`.
* Fixes problems with sphinx build.
* Fixes JWTExtendedException get_headers function to work propperly with werkzeug.