### PR TITLE
settings applications: simplify token queries

### DIFF
--- a/invenio_oauth2server/views/settings.py
+++ b/invenio_oauth2server/views/settings.py
@@ -115,7 +115,7 @@ def index():
     ).all()
 
     tokens = (
-        Token.query.options(db.joinedload("client"))
+        Token.query.join(Client, isouter=True)
         .filter(
             Token.user_id == current_user.get_id(),
             Token.is_personal == True,  # noqa
@@ -126,7 +126,7 @@ def index():
     )
 
     authorized_apps = (
-        Token.query.options(db.joinedload("client"))
+        Token.query.join(Client, isouter=True)
         .filter(
             Token.user_id == current_user.get_id(),
             Token.is_personal == False,  # noqa


### PR DESCRIPTION
* closes https://github.com/zenodo/rdm-project/issues/480

Note: there's no proof that this will not result in timeout in the browser, as I couldn't reproduce the error locally. Should be tested in QA first

Previous generated SQL query:
```
SELECT 
	oauth2server_token.id AS oauth2server_token_id,
	oauth2server_token.client_id AS oauth2server_token_client_id, 
	oauth2server_token.user_id AS oauth2server_token_user_id, 
	oauth2server_token.token_type AS oauth2server_token_token_type, 
	oauth2server_token.access_token AS oauth2server_token_access_token, 
	oauth2server_token.refresh_token AS oauth2server_token_refresh_token, 
	oauth2server_token.expires AS oauth2server_token_expires,
	oauth2server_token._scopes AS oauth2server_token__scopes,
	oauth2server_token.is_personal AS oauth2server_token_is_personal,
	oauth2server_token.is_internal AS oauth2server_token_is_internal,
	oauth2server_client_1.name AS oauth2server_client_1_name,
	oauth2server_client_1.description AS oauth2server_client_1_description, 
	oauth2server_client_1.website AS oauth2server_client_1_website, 
	oauth2server_client_1.user_id AS oauth2server_client_1_user_id, 
	oauth2server_client_1.client_id AS oauth2server_client_1_client_id, 
	oauth2server_client_1.client_secret AS oauth2server_client_1_client_secret,
	oauth2server_client_1.is_confidential AS oauth2server_client_1_is_confidential, 
	oauth2server_client_1.is_internal AS oauth2server_client_1_is_internal, 
	oauth2server_client_1._redirect_uris AS oauth2server_client_1__redirect_uris, 
	oauth2server_client_1._default_scopes AS oauth2server_client_1__default_scopes 
FROM 
	oauth2server_client, oauth2server_token 
LEFT OUTER JOIN 
	oauth2server_client AS oauth2server_client_1 ON oauth2server_client_1.client_id = oauth2server_token.client_id 
WHERE 
	oauth2server_token.user_id = %(user_id_1)s 
	AND oauth2server_token.is_personal = true 
	AND oauth2server_token.is_internal = false 
	AND oauth2server_client.is_internal = true
```

Current generated SQL query:
```
SELECT 
	oauth2server_token.id AS oauth2server_token_id, 
	oauth2server_token.client_id AS oauth2server_token_client_id, 
	oauth2server_token.user_id AS oauth2server_token_user_id,
	oauth2server_token.token_type AS oauth2server_token_token_type, 
	oauth2server_token.access_token AS oauth2server_token_access_token, 
	oauth2server_token.refresh_token AS oauth2server_token_refresh_token, 
	oauth2server_token.expires AS oauth2server_token_expires, 
	oauth2server_token._scopes AS oauth2server_token__scopes, 
	oauth2server_token.is_personal AS oauth2server_token_is_personal, 
	oauth2server_token.is_internal AS oauth2server_token_is_internal 
FROM 
	oauth2server_token 
LEFT OUTER JOIN 
	oauth2server_client ON oauth2server_client.client_id = oauth2server_token.client_id 
WHERE 
	oauth2server_token.user_id = %(user_id_1)s 
	AND oauth2server_token.is_personal = true 
	AND oauth2server_token.is_internal = false 
	AND oauth2server_client.is_internal = true
```