### PR TITLE
fix(chore): DeprecationWarning stdlib

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,11 @@
 Changes
 =======
 
+Version v4.0.0 (released 2026-01-29)
+
+- chore(setup): bump dependencies
+- fix(chore): DeprecationWarning stdlib
+
 Version v3.3.3 (released 2026-01-27)
 
 - chore(setup): pin dependencies

--- a/invenio_oauth2server/__init__.py
+++ b/invenio_oauth2server/__init__.py
@@ -112,7 +112,7 @@ from .decorators import require_api_auth, require_oauth_scopes
 from .ext import InvenioOAuth2Server, InvenioOAuth2ServerREST
 from .proxies import current_oauth2server
 
-__version__ = "3.3.3"
+__version__ = "4.0.0"
 
 __all__ = (
     "__version__",

--- a/invenio_oauth2server/alembic/3d7f57a61d67_change_expires_at_type.py
+++ b/invenio_oauth2server/alembic/3d7f57a61d67_change_expires_at_type.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Invenio.
+# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2026 Graz University of Technology.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+
+"""Change expires_at type to utc aware datetime."""
+
+from alembic import op
+from invenio_db import db
+
+# revision identifiers, used by Alembic.
+revision = "3d7f57a61d67"
+down_revision = "4e57407b8e4a"
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.alter_column(
+        "oauth2server_token",
+        "expires",
+        type_=db.UTCDateTime(),
+        existing_type=db.DateTime(),
+        existing_nullable=True,
+    )
+
+
+def downgrade():
+    """Downgrade database."""
+    op.alter_column(
+        "oauth2server_token",
+        "expires",
+        type_=db.DateTime(),
+        existing_type=db.UTCDateTime(),
+        existing_nullable=True,
+    )

--- a/invenio_oauth2server/models.py
+++ b/invenio_oauth2server/models.py
@@ -2,7 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2023-2024 Graz University of Technology.
+# Copyright (C) 2023-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -353,7 +353,7 @@ class Token(db.Model):
         nullable=True,
     )
 
-    expires = db.Column(db.DateTime, nullable=True)
+    expires = db.Column(db.UTCDateTime, nullable=True)
 
     _scopes = db.Column(db.Text)
 

--- a/invenio_oauth2server/provider.py
+++ b/invenio_oauth2server/provider.py
@@ -2,14 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2024-2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Configuration of Flask-OAuthlib provider."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from importlib.metadata import version
 
 from flask import current_app, g
@@ -124,7 +124,7 @@ def save_token(token, request, *args, **kwargs):
         db.session.commit()
 
     expires_in = token.get("expires_in")
-    expires = datetime.utcnow() + timedelta(seconds=int(expires_in))
+    expires = datetime.now(timezone.utc) + timedelta(seconds=int(expires_in))
 
     tok = Token(
         access_token=token["access_token"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,10 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     cachelib>=0.1
-    Flask-OAuthlib-Invenio>=1.0.0,<2.0.0
+    Flask-OAuthlib-Invenio>=2.0.0,<3.0.0
     Flask-WTF>=0.14.3
     future>=0.16.0
-    invenio-accounts>=6.0.0,<7.0.0
+    invenio-accounts>=7.0.0,<8.0.0
     invenio-base>=2.3.0,<3.0.0
     invenio-i18n>=3.0.0,<4.0.0
     invenio-theme>=4.0.0,<5.0.0
@@ -43,12 +43,12 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black-ng>=0.4.0
-    pytest-invenio>=3.0.0,<4.0.0
-    invenio-admin>=1.2.1
+    pytest-black>=0.6.0
+    pytest-invenio>=4.0.0,<5.0.0
+    invenio-admin>=1.6.0,<2.0.0
     sphinx>=4.5
     redis>=2.10.5
-    invenio-db[mysql,postgresql,versioning]>=2.0.0,<3.0.0
+    invenio-db[mysql,postgresql,versioning]>=2.2.0,<3.0.0
 # Kept for backwards compatibility
 admin =
 docs =

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -2,14 +2,14 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2015-2018 CERN.
-# Copyright (C) 2023-2024 Graz University of Technology.
+# Copyright (C) 2023-2026 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Test OAuth2Server providers."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from flask import json, url_for
@@ -796,7 +796,7 @@ def test_expired_refresh_flow(provider_fixture):
             assert r.status_code == 200
 
             Token.query.filter_by(access_token=old_access_token).update(
-                dict(expires=datetime.utcnow() - timedelta(seconds=1))
+                dict(expires=datetime.now(timezone.utc) - timedelta(seconds=1))
             )
             db.session.commit()
 
@@ -892,7 +892,6 @@ def test_not_allowed_public_refresh_flow(provider_fixture):
             assert json_resp["user"]["id"]
             refresh_token = json_resp["refresh_token"]
             old_access_token = json_resp["access_token"]
-
             # Access token valid
             r = client.get(
                 url_for("invenio_oauth2server.info", access_token=old_access_token)
@@ -900,7 +899,7 @@ def test_not_allowed_public_refresh_flow(provider_fixture):
             assert r.status_code == 200
 
             Token.query.filter_by(access_token=old_access_token).update(
-                dict(expires=datetime.utcnow() - timedelta(seconds=1))
+                dict(expires=datetime.now(timezone.utc) - timedelta(seconds=1))
             )
             db.session.commit()
 


### PR DESCRIPTION
* datetime.datetime.utcnow() is deprecated and scheduled for removal in
  a future version. Use timezone-aware objects to represent datetimes in
  UTC: datetime.datetime.now(datetime.UTC).

* the decision was made to move to utc aware timestamps
