### PR TITLE
Remove `importlib-metadata`

### DIFF
--- a/invenio_oauth2server/config.py
+++ b/invenio_oauth2server/config.py
@@ -71,7 +71,7 @@ OAUTH2SERVER_JWT_AUTH_HEADER_TYPE = "Bearer"
     `JWT  <https://jwt.io>`_
 """
 
-OAUTH2SERVER_JWT_VERIFICATION_FACTORY = "invenio_oauth2server.utils:" "jwt_verify_token"
+OAUTH2SERVER_JWT_VERIFICATION_FACTORY = "invenio_oauth2server.utils:jwt_verify_token"
 """Import path of factory used to verify JWT.
 
 The ``request.headers`` should be passed as parameter.

--- a/invenio_oauth2server/models.py
+++ b/invenio_oauth2server/models.py
@@ -126,7 +126,7 @@ class Client(db.Model):
         info=dict(
             label=_("Description"),
             description=_(
-                "Optional. Description of the application" " (displayed to users)."
+                "Optional. Description of the application (displayed to users)."
             ),
         ),
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,6 @@ dependencies = [
   "flask-oauthlib-invenio>=2.0.0,<3.0.0",
   "flask-wtf>=0.14.3",
   "future>=0.16.0",
-  "importlib_metadata>=4.4",
   "invenio-accounts>=9.0.0,<10.0.0",
   "invenio-base>=2.3.0,<3.0.0",
   "invenio-i18n>=4.0.0,<5.0.0",


### PR DESCRIPTION
Like https://github.com/inveniosoftware/invenio-base/pull/206

The minimum Python version here is 3.9, so we can safely remove the dependency.